### PR TITLE
Update ctest invocations and README.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,8 @@ project(RADAE
 
 option(AVX "Enable AVX CPU optimizations." ON)
 
-if(NOT CODEC2_DEV_BUILD_DIR)
-    set(CODEC2_DEV_BUILD_DIR $HOME/codec2-dev/build_linux )
+if(NOT CODEC2_DIR)
+    set(CODEC2_DIR $HOME/codec2-dev/build_linux )
 endif()
 
 # Build opus with FARGAN support.
@@ -40,26 +40,26 @@ enable_testing()
 
 # Basic test of radae/radae.py code at rate Rs - pass condition is simply that it runs
 add_test(NAME inference_model5
-         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; ./inference.sh model05/checkpoints/checkpoint_epoch_100.pth wav/brian_g8sez.wav /dev/null --EbNodB 10")
+         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; PATH=${CMAKE_BINARY_DIR}/src:$PATH ./inference.sh model05/checkpoints/checkpoint_epoch_100.pth wav/brian_g8sez.wav /dev/null --EbNodB 10")
 
 # Vanilla tests of model 17 & 18, just to confirm they're working
 add_test(NAME inference_model17
-         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
+         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; PATH=${CMAKE_BINARY_DIR}/src:$PATH \
                         ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/brian_g8sez.wav /dev/null \
                         --EbNodB 0 --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3")
 add_test(NAME inference_model18
-         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
+         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; PATH=${CMAKE_BINARY_DIR}/src:$PATH \
                         ./inference.sh model18/checkpoints/checkpoint_epoch_100.pth wav/brian_g8sez.wav /dev/null --latent-dim 40 \
                         --EbNodB 0 --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3")
 
 # Stateful encoder sanity test (no channel noise)
 add_test(NAME stateful_encoder
-         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; ./stateful_encoder.sh model05/checkpoints/checkpoint_epoch_100.pth wav/peter.wav /dev/null --loss_test 0.2")
+         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; PATH=${CMAKE_BINARY_DIR}/src:$PATH ./stateful_encoder.sh model05/checkpoints/checkpoint_epoch_100.pth wav/peter.wav /dev/null --loss_test 0.2")
          set_tests_properties(stateful_encoder PROPERTIES PASS_REGULAR_EXPRESSION "PASS")
 
 # Stateful decoder sanity test (no channel noise)
 add_test(NAME stateful_decoder
-         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; ./stateful_decoder.sh model05/checkpoints/checkpoint_epoch_100.pth wav/peter.wav /dev/null --loss_test 0.2")
+         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; PATH=${CMAKE_BINARY_DIR}/src:$PATH ./stateful_decoder.sh model05/checkpoints/checkpoint_epoch_100.pth wav/peter.wav /dev/null --loss_test 0.2")
          set_tests_properties(stateful_decoder PROPERTIES PASS_REGULAR_EXPRESSION "PASS")
 
 # DIGITAL SYMBOL BER TESTS ----------------------------------------------------------
@@ -69,18 +69,18 @@ add_test(NAME stateful_decoder
 # Vanilla high SNR test
 add_test(NAME inference_ber
          COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
-                        ./inference.sh model05/checkpoints/checkpoint_epoch_100.pth wav/peter.wav /dev/null --rate_Fs --pilots \
+                        PATH=${CMAKE_BINARY_DIR}/src:$PATH ./inference.sh model05/checkpoints/checkpoint_epoch_100.pth wav/peter.wav /dev/null --rate_Fs --pilots \
                         --EbNodB 100 --cp 0.004 --pilot_eq --eq_ls --ber_test")
          set_tests_properties(inference_ber PROPERTIES PASS_REGULAR_EXPRESSION "BER: 0.000")
 
 # As above but on AWGN at operating point Eb/No - gives LS EQ a work out
 add_test(NAME inference_ber_awgn
-         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; test/inference_ber_awgn.sh")
+         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; PATH=${CMAKE_BINARY_DIR}/src:$PATH test/inference_ber_awgn.sh")
          set_tests_properties(inference_ber_awgn PROPERTIES PASS_REGULAR_EXPRESSION "PASS")
 
 # As above but on MPP at operating point Eb/No
 add_test(NAME inference_ber_mpp
-         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; test/inference_ber_mpp.sh")
+         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; PATH=${CMAKE_BINARY_DIR}/src:$PATH test/inference_ber_mpp.sh")
          set_tests_properties(inference_ber_mpp PROPERTIES PASS_REGULAR_EXPRESSION "PASS")
 
 # ML SYMBOL OP POINT LOSS TESTS ----------------------------------------------------------
@@ -89,21 +89,21 @@ add_test(NAME inference_ber_mpp
 
 add_test(NAME inference_loss_model5
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
-                       ./inference.sh model05/checkpoints/checkpoint_epoch_100.pth wav/brian_g8sez.wav /dev/null \
+                       PATH=${CMAKE_BINARY_DIR}/src:$PATH ./inference.sh model05/checkpoints/checkpoint_epoch_100.pth wav/brian_g8sez.wav /dev/null \
                        --EbNodB -2.5  --freq_offset 1 --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 \
                        --loss_test 0.3")
                        set_tests_properties(inference_loss_model5 PROPERTIES PASS_REGULAR_EXPRESSION "PASS")
 
 add_test(NAME inference_loss_model17
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
-                       ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/brian_g8sez.wav /dev/null \
+                       PATH=${CMAKE_BINARY_DIR}/src:$PATH ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/brian_g8sez.wav /dev/null \
                        --EbNodB 0.5  --freq_offset 1 --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 \
                        --loss_test 0.3")
                        set_tests_properties(inference_loss_model17 PROPERTIES PASS_REGULAR_EXPRESSION "PASS")
 
 add_test(NAME inference_loss_model18
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
-                       ./inference.sh model18/checkpoints/checkpoint_epoch_100.pth wav/brian_g8sez.wav /dev/null --latent-dim 40 \
+                       PATH=${CMAKE_BINARY_DIR}/src:$PATH ./inference.sh model18/checkpoints/checkpoint_epoch_100.pth wav/brian_g8sez.wav /dev/null --latent-dim 40 \
                        --EbNodB 3.5  --freq_offset 1 --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 \
                        --loss_test 0.3")
                        set_tests_properties(inference_loss_model18 PROPERTIES PASS_REGULAR_EXPRESSION "PASS")
@@ -113,7 +113,7 @@ add_test(NAME inference_loss_model18
 # Generate rx.f32 rate Fs IQ samples, run through stand alone rx/py receiver, measure loss and acquisition time
 add_test(NAME rx_loss_acq_time
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
-                       ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/all.wav /dev/null --EbNodB 3  --freq_offset 10 \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/all.wav /dev/null --EbNodB 3  --freq_offset 10 \
                        --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 --correct_freq_offset --write_rx rx.f32; \
                        rm -f features_rx_out.f32; \
                        ./rx.sh model17/checkpoints/checkpoint_epoch_100.pth rx.f32 /dev/null \
@@ -124,19 +124,19 @@ add_test(NAME rx_loss_acq_time
 # Estimating C/No on multipath channels using a chirp
 add_test(NAME chirp_mpp
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
-                       ./test/chirp_mpp.sh ${CODEC2_DEV_BUILD_DIR} -16")
+                       PATH=${CMAKE_BINARY_DIR}/src:$PATH ./test/chirp_mpp.sh ${CODEC2_DIR} -16")
                        set_tests_properties(chirp_mpp PROPERTIES PASS_REGULAR_EXPRESSION "PASS")
 
 # Low SNR ota_test.sh, with chirp measurement, AWGN
 add_test(NAME ota_test_awgn
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
-                       ./test/ota_test_cal.sh ~/codec2-dev/build_linux/ -21 0.3")
+                       PATH=${CMAKE_BINARY_DIR}/src:${CODEC2_DIR}/src:$PATH ./test/ota_test_cal.sh ${CODEC2_DIR} -21 0.3")
 
 # Low SNR ota_test.sh, with chirp measurement, MPP, high loss threshold as we only care about gross errors,
 # like stuck in false sync
 add_test(NAME ota_test_mpp
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
-                       ./test/ota_test_cal.sh ~/codec2-dev/build_linux/ -24 0.4 --mpp --freq -25")
+                       PATH=${CMAKE_BINARY_DIR}/src:${CODEC2_DIR}/src:$PATH ./test/ota_test_cal.sh ${CODEC2_DIR} -24 0.4 --mpp --freq -25")
 
 
 # Acquisition tests ------------------------------------------------------------------------------------
@@ -144,8 +144,9 @@ add_test(NAME ota_test_mpp
 # noise-only test, should not acquire for 120s (currently set at 30s as it's too slow)
 add_test(NAME acq_noise
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; \
                        dd if=/dev/zero of=/dev/stdout bs=16000 count=30 | \
-                       ${CODEC2_DEV_BUILD_DIR}/src/ch - rx.int16 --No -20; \          # real int16 output
+                       ${CODEC2_DIR}/src/ch - rx.int16 --No -20; \          # real int16 output
                        cat rx.int16 | python3 int16tof32.py --zeropad > rx.f32; \     # ..IQIQI.. .f32 with Q == 0
                        ./rx.sh model17/checkpoints/checkpoint_epoch_100.pth rx.f32 /dev/null \
                        --pilots --pilot_eq --bottleneck 3 --cp 0.004 --coarse_mag --time_offset -16")
@@ -154,9 +155,9 @@ add_test(NAME acq_noise
 # sine wave + noise-only test, should not acquire 
 add_test(NAME acq_sine
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
-                       ${CODEC2_DEV_BUILD_DIR}/misc/mksine - 1000 30 | \
-                       ${CODEC2_DEV_BUILD_DIR}/src/ch - rx.int16 --No -20; \          # real int16 output
-                       cat rx.int16 | python3 int16tof32.py --zeropad > rx.f32; \     # ..IQIQI.. .f32 with Q == 0
+                       ${CODEC2_DIR}/misc/mksine - 1000 30 | \
+                       ${CODEC2_DIR}/src/ch - rx.int16 --No -20; \          # real int16 output
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; cat rx.int16 | python3 int16tof32.py --zeropad > rx.f32; \     # ..IQIQI.. .f32 with Q == 0
                        ./rx.sh model17/checkpoints/checkpoint_epoch_100.pth rx.f32 /dev/null \
                        --pilots --pilot_eq --bottleneck 3 --cp 0.004 --coarse_mag --time_offset -16")
                        set_tests_properties(acq_sine PROPERTIES PASS_REGULAR_EXPRESSION "Acquisition failed")
@@ -164,6 +165,7 @@ add_test(NAME acq_sine
 # Worst case: 0dB SNR MPP
 add_test(NAME acq_mpp
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; F_OFF=10; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; \
                        test/make_g.sh; \
                        ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/all.wav /dev/null \
                        --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 \
@@ -175,6 +177,7 @@ add_test(NAME acq_mpp
 # 0dB SNR MPG (slow fading to simulate quasi-stationary notches)
 add_test(NAME acq_mpg
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; F_OFF=40; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; \
                        test/make_g.sh; \
                        ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/all.wav /dev/null \
                        --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 \
@@ -186,6 +189,7 @@ add_test(NAME acq_mpg
 # 3dB SNR MPD (very fast fading, we expect reduced perf, so raise SNR)
 add_test(NAME acq_mpd
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; F_OFF=-34.5; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH;
                        test/make_g.sh; \
                        ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/all.wav /dev/null \
                        --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 \
@@ -197,6 +201,7 @@ add_test(NAME acq_mpd
 # Acquisition test as above with an interfering sine wave at -3dBc on our signal, we relax acq time target to 2s
 add_test(NAME acq_sine_mpp
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; \
                        test/make_g.sh; \
                        ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/brian_g8sez.wav /dev/null \
                        --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 \
@@ -210,6 +215,7 @@ add_test(NAME acq_sine_mpp
 # basic test of streaming Tx/Rx, compare to vanilla Tx in inference.py
 add_test(NAME radae_tx_basic
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; \
                        ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/brian_g8sez.wav /dev/null \
                        --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 --write_rx rx.f32 --correct_freq_offset; \
                        cat features_in.f32 | python3 radae_tx.py model17/checkpoints/checkpoint_epoch_100.pth > rx.f32
@@ -219,12 +225,15 @@ add_test(NAME radae_tx_basic
 
 # complex bandpass filter
 add_test(NAME complex_bpf
-         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; python3 -c 'from radae import complex_bpf_test; complex_bpf_test(0)'")
+         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; \
+                       python3 -c 'from radae import complex_bpf_test; complex_bpf_test(0)'")
                 set_tests_properties(complex_bpf PROPERTIES PASS_REGULAR_EXPRESSION "PASS")
 
 # compare rx.py in with vanilla and stateful core decoder, tests just ML part of streaming receiver
 add_test(NAME rx_stateful
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; \
                        ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/brian_g8sez.wav /dev/null \
                        --EbNodB 0 --freq_offset 11 \
                        --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 --write_rx rx.f32 --correct_freq_offset; \
@@ -239,6 +248,7 @@ add_test(NAME rx_stateful
 # compare rx.py in vanilla and streaming mode, tests streaming receiver DSP and ML
 add_test(NAME rx_streaming
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; \
                        ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/brian_g8sez.wav /dev/null \
                         --EbNodB 0 --freq_offset 11 \
                        --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 --write_rx rx.f32 --correct_freq_offset; \
@@ -253,6 +263,7 @@ add_test(NAME rx_streaming
 # basic test of streaming rx, run rx in vanilla and streaming , compare
 add_test(NAME radae_rx_basic
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; \
                        ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/brian_g8sez.wav /dev/null \
                        --EbNodB 10 --freq_offset 11 \
                        --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 --write_rx rx.f32 --correct_freq_offset; \
@@ -266,6 +277,7 @@ add_test(NAME radae_rx_basic
 # SNR=-2dB AWGN
 add_test(NAME radae_rx_awgn
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; \
                        ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/all.wav /dev/null \
                        --EbNodB 1 --freq_offset 13 \
                        --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 --time_offset -16 --write_rx rx.f32  \
@@ -279,6 +291,7 @@ add_test(NAME radae_rx_awgn
 # We don't don't bother checking acquisition time on this channel, as it's a severe case.
 add_test(NAME radae_rx_mpp
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; \
                        test/make_g.sh; \
                        ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/all.wav /dev/null \
                        --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 --time_offset -16 \
@@ -291,6 +304,7 @@ add_test(NAME radae_rx_mpp
 # SNR=0dB MPG
 add_test(NAME radae_rx_mpg
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; \
                        test/make_g.sh; \
                        ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/all.wav /dev/null \
                        --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 --time_offset -16 \
@@ -303,6 +317,7 @@ add_test(NAME radae_rx_mpg
 # SNR=3dB MPD, nasty channel that is fast fading but generally high SNR - so mission here is "don't break" rather than low SNR
 add_test(NAME radae_rx_mpd
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; \
                        test/make_g.sh; \
                        ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/all.wav /dev/null \
                        --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 --time_offset -16 \
@@ -315,6 +330,7 @@ add_test(NAME radae_rx_mpd
 # SNR=-2dB AWGN ~5 Hz/min = 5/60 Hz/s freq drift
 add_test(NAME radae_rx_dfdt
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; \
                       ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/all.wav /dev/null \
                        --EbNodB 1 --freq_offset 13 --df_dt 0.1 \
                        --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 --time_offset -16 --write_rx rx.f32  \
@@ -326,6 +342,7 @@ add_test(NAME radae_rx_dfdt
 # SNR=7dB ability to handle small differences in sample rate between tx and rx (delta Fs)
 add_test(NAME radae_rx_dfs
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; \
                        ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/brian_g8sez.wav /dev/null \
                        --EbNodB 10 --freq_offset 11 \
                        --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 --write_rx rx.f32 --correct_freq_offset; \
@@ -338,6 +355,7 @@ add_test(NAME radae_rx_dfs
 # in order to exercise code.  Nice thing about "nin" design is it allows us to get meaningful "loss.py" results, ie no frames are lost.
 add_test(NAME radae_rx_slip_plus
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; \
                        ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/brian_g8sez.wav /dev/null \
                        --EbNodB 10 --freq_offset 11 \
                        --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 --write_rx rx.f32 --correct_freq_offset --prepend_noise 0.08; \
@@ -349,6 +367,7 @@ add_test(NAME radae_rx_slip_plus
 # Test ability to handle buffer slips due to sample clock offsets, rx ADC clock < tx ADC clock
 add_test(NAME radae_rx_slip_minus
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; \
                        ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/brian_g8sez.wav /dev/null \
                        --EbNodB 10 --freq_offset 31 \
                        --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 --write_rx rx.f32 --correct_freq_offset --prepend_noise 0.11; \
@@ -360,6 +379,7 @@ add_test(NAME radae_rx_slip_minus
 # profiles a run with a 50 second file (no pass/fail, run with -V to get a rough idea of execution time)
 add_test(NAME radae_rx_profile
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; \
                        ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth wav/all.wav /dev/null \
                        --EbNodB 1 --freq_offset 13 --df_dt 0.1 \
                        --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 --time_offset -16 --write_rx rx.f32  \
@@ -369,6 +389,7 @@ add_test(NAME radae_rx_profile
 # performs a run using the streaming FARGAN decoder, ie the full simplex rx decode stack.  No pass/fail, just for characterisation of run time
 add_test(NAME radae_rx_fargan
         COMMAND bash -c "WAV='wav/all.wav'; cd ${CMAKE_SOURCE_DIR}; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; \
                        ./inference.sh model17/checkpoints/checkpoint_epoch_100.pth $WAV /dev/null \
                        --EbNodB 10 --freq_offset 13 --df_dt -0.1 \
                        --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 --time_offset -16 --write_rx rx.f32  \
@@ -382,6 +403,7 @@ add_test(NAME radae_rx_fargan
 # to pass (but low SNR not really the aim of this test), --foff_err forces a false sync state after first sync
 add_test(NAME radae_rx_mpp_aux
         COMMAND sh -c "cd ${CMAKE_SOURCE_DIR}; \
+                       export PATH=${CMAKE_BINARY_DIR}/src:$PATH; \
                        test/make_g.sh; \
                        ./inference.sh model19_check3/checkpoints/checkpoint_epoch_100.pth wav/all.wav /dev/null \
                        --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 --time_offset -16 --auxdata \

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The RDOVAE derived Python source code is released under the two-clause BSD licen
 
 sox, python3, python3-matplotlib, python3-venv and python3-tqdm, octave, octave-signal, cmake.  Pytorch should be installed using the instructions from the [pytorch](https://pytorch.org/get-started/locally/) web site. 
 
-*Note: depending on your Linux distro, you may need to run `python3 -m venv radae-venv` followed by `export PATH=`pwd`/radae-venv/bin:$PATH` in order for PyTorch to install on your system. Additionally, matplotlib and tqdm may also need to be installed inside the venv instead of via packages (e.g. `pip3 install matplotlib` after setting `PATH`.); ctests may fail otherwise.*
+*Note: depending on your Linux distro, you may need to run `python3 -m venv radae-venv` followed by `export PATH=\`pwd\`/radae-venv/bin:$PATH` in order for PyTorch to install on your system. Additionally, matplotlib and tqdm may also need to be installed inside the venv instead of via packages (e.g. `pip3 install matplotlib` after setting `PATH`.); ctests may fail otherwise.*
 
 ## codec2-dev
 
@@ -88,9 +88,9 @@ cmake ..
 make
 ctest
 ```
-To list tests `ctest -N`, to run just one test `ctest -R inference_model5`, to run in verbose mode `ctest -V -R inference_model5`.  You can change the paths to `codec2-dev` and `opus` on the `cmake` command line:
+To list tests `ctest -N`, to run just one test `ctest -R inference_model5`, to run in verbose mode `ctest -V -R inference_model5`.  You can change the path to `codec2-dev` on the `cmake` command line:
 ```
-cmake -DCODEC2_DEV=~/tmp/codec2-dev ..
+cmake -DCODEC2_DIR=~/tmp/codec2-dev/build_linux ..
 ```
 A lot of the tests generate a float IQ sample file.  You can listen to this file with: 
 ```

--- a/README.md
+++ b/README.md
@@ -59,7 +59,14 @@ The RDOVAE derived Python source code is released under the two-clause BSD licen
 
 sox, python3, python3-matplotlib, python3-venv and python3-tqdm, octave, octave-signal, cmake.  Pytorch should be installed using the instructions from the [pytorch](https://pytorch.org/get-started/locally/) web site. 
 
-*Note: depending on your Linux distro, you may need to run `python3 -m venv radae-venv` followed by `export PATH=\`pwd\`/radae-venv/bin:$PATH` in order for PyTorch to install on your system. Additionally, matplotlib and tqdm may also need to be installed inside the venv instead of via packages (e.g. `pip3 install matplotlib` after setting `PATH`.); ctests may fail otherwise.*
+*Note: depending on your Linux distro, you may need to run something like the following in order for PyTorch to install on your system:*
+
+```
+python3 -m venv radae-venv
+export PATH=`pwd`/radae-venv/bin:$PATH`
+```
+
+*Additionally, matplotlib and tqdm may also need to be installed inside the venv instead of via packages (e.g. `pip3 install matplotlib` after setting `PATH`.); ctests may fail otherwise.*
 
 ## codec2-dev
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ The RDOVAE derived Python source code is released under the two-clause BSD licen
 
 ## Packages
 
-sox, python3, python3-matplotlib and python3-tqdm, octave, octave-signal, cmake.  Pytorch should be installed using the instructions from the [pytorch](https://pytorch.org/get-started/locally/) web site. 
+sox, python3, python3-matplotlib, python3-venv and python3-tqdm, octave, octave-signal, cmake.  Pytorch should be installed using the instructions from the [pytorch](https://pytorch.org/get-started/locally/) web site. 
+
+*Note: depending on your Linux distro, you may need to run `python3 -m venv radae-venv` followed by `export PATH=`pwd`/radae-venv/bin:$PATH` in order for PyTorch to install on your system. Additionally, matplotlib and tqdm may also need to be installed inside the venv instead of via packages (e.g. `pip3 install matplotlib` after setting `PATH`.); ctests may fail otherwise.*
 
 ## codec2-dev
 


### PR DESCRIPTION
I attempted to install radae into a fresh Ubuntu 24.04 VM and ended up running into issues with ctests and setup. This PR does the following:

1. Updates `README.md` by adding content indicating that a Python venv may be necessary.
2. Update `CMakeLists.txt` as follows:
    * Sets `PATH` for each ctest to allow system to find various Codec2 utilities in `CODEC2_DIR` and `lpcnet_demo`.
    * Renames `CODEC2_DEV_BUILD_DIR` to `CODEC2_DIR` to match `README.md`.