### PR TITLE
August 2024 Test Campaign #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A hybrid Machine Learning/DSP system for sending speech over HF radio channels. 
 
 ## Scope 
 
-This repo is intended to support the authors experimental work, with just enough information for the advanced experimenter to reproduce aspects of the work.  It is not intended to be a polished distribution for general use.  Unless otherwise stated, the code is this repo is intended to run only on Ubuntu Linux 22.
+This repo is intended to support the authors experimental work, with just enough information for the advanced experimenter to reproduce aspects of the work.  The focus is on waveform development.  It is not intended to be a polished distribution for general use or to work across multiple Linux distros and operating systems. Unless otherwise stated, the code is this repo is intended to run only on Ubuntu Linux 22.
 
 # Quickstart
 
@@ -64,7 +64,7 @@ sox, python3, python3-matplotlib and python3-tqdm, octave, octave-signal, cmake.
 Supplies some utilities used for `ota_test.sh` and `evaluate.sh`
 ```
 cd ~
-git clone git@github.com:drowe67/codec2-dev.git
+git clone https://github.com/drowe67/codec2-dev.git
 cd codec2-dev
 mkdir build_linux
 cd build_linux
@@ -76,6 +76,8 @@ make ch mksine tlininterp
 
 Builds the FARGAN vocoder and ctest framework, most of RADAE is in Python.
 ```
+cd ~
+git clone https://github.com/drowe67/radae.git
 cd radae
 mkdir build
 cd build
@@ -428,7 +430,7 @@ This section contains some notes on setting up a web server to run `ota_test.sh`
    sudo pip3 install matplotlib
    sudo -u www-data python3 -c "import matplotlib"
    ```
-   The presence of the packages can be checked by mimicing the www-data user (the last line in each step above should return nothing if all is well).
+   The presence of the packages can be checked by mimicing the www-data user (the last line in each step above should not fail if all is well).
 
 1. Configure Apache for CGI and serving pages from our `~/public_html` dir.
    ```
@@ -442,9 +444,9 @@ This section contains some notes on setting up a web server to run `ota_test.sh`
    chmod 755 public_html
    sudo usermod -a -G <username> www-data
    ```
-   To let CGI scripts run from ~/public_html I placed this in my `/etc/apache2.conf`:
+   To let CGI scripts run from ~/public_html I placed this in my `/etc/apache2/apache2.conf`:
    ```
-   <Directory "/home/david/public_html">
+   <Directory "/home/<username>/public_html">
       Options +ExecCGI
       AddHandler cgi-script .cgi
    </Directory>  
@@ -457,6 +459,11 @@ This section contains some notes on setting up a web server to run `ota_test.sh`
    ln -s ~/radae/public_html/tx_form.html tx_form.html
    ln -s ~/radae/public_html/tx_process.cgi tx_process.cgi
    ``` 
+
+1. Edit the path to `CODEC2_DEV` in `radae/public_html/tx_process.cgi`:
+   ```
+   my_env["CODEC2_DEV"] = "/home/<username>/codec2-dev"
+   ```
 
 1. Note that files created when the CGI process run (e.g. `/tmp/input.wav`) get put in a sandbox rather than directly in `/tmp`.  This is a systemd security feature.  You can find the files with:
    ```

--- a/ptt_test.conf
+++ b/ptt_test.conf
@@ -1,0 +1,12 @@
+# conf file for ptt_test.sh
+
+rigctl_model       3061
+serial_port        /dev/ttyUSB0
+mic_card_num       2
+mic_card_dev       0
+rig_in_card_num    3
+rig_in_device      0
+rig_out_card_num   4
+rig_out_card_dev   1
+speaker_card_num   0
+speaker_card_dev   0

--- a/ptt_test.sh
+++ b/ptt_test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+echo "---------------------"
+echo "Available audio cards"
+echo "---------------------\n"
+
+aplay -l | grep card
+
+printf "\nselect mic card number: "
+read -N 1 mic_card_num
+printf "\nselect rig input card number: "
+read -N 1 rig_card_num
+printf "\n"
+
+mic_card=$(aplay -l | grep "card ${mic_card_num}" | head -n 1 | tr -s ' ' | cut -d' ' -f3)
+rig_card=$(aplay -l | grep "card ${rig_card_num}" | head -n 1 | tr -s ' ' | cut -d' ' -f3)
+
+echo $mic_card
+echo $rig_card
+
+arecord --device "plughw:CARD=${mic_card},DEV=0" -f S16_LE -c 1 -r 16000 | \
+./build/src/lpcnet_demo -features - - | \
+python3 radae_tx.py model19_check3/checkpoints/checkpoint_epoch_100.pth --auxdata | \
+python3 f32toint16.py --real --scale 8192 | aplay -f S16_LE --device "plughw:CARD=${rig_card},DEV=0"
+
+echo "RADAE transmitter running!  Ctrl-C to exit"

--- a/ptt_test.sh
+++ b/ptt_test.sh
@@ -7,10 +7,21 @@ function clean_up {
     exit 1
 }
 
-function kick_off_tx_process {
-    arecord --device "plughw:CARD=${mic_card},DEV=0" -f S16_LE -c 1 -r 16000 | \
+function kick_off_ssb_tx_process {
+    ( arecord --device "plughw:CARD=${mic_card},DEV=0" -f S16_LE -c 1 -r 8000 & echo $! >tx_pid ) | \
+    aplay -f S16_LE --device "plughw:CARD=${rig_card},DEV=0" &
+
+    echo
+    echo "SSB transmitter running!  Any key to exit"
+    echo
+    cat tx_pid
+}
+
+function kick_off_radae_tx_process {
+    # note we store PID of process before radae_tx.py, killing should mean end of over pilot sequence is sent by radae_tx.py (TBC)
+    ( arecord --device "plughw:CARD=${mic_card},DEV=0" -f S16_LE -c 1 -r 16000 & echo $! >tx_pid ) | \
     ./build/src/lpcnet_demo -features - - | \
-    ( python3 radae_tx.py model19_check3/checkpoints/checkpoint_epoch_100.pth --auxdata & echo $! >tx_pid ) | \
+    python3 radae_tx.py model19_check3/checkpoints/checkpoint_epoch_100.pth --auxdata | \
     python3 f32toint16.py --real --scale 8192 | aplay -f S16_LE --device "plughw:CARD=${rig_card},DEV=0" &
 
     echo
@@ -37,19 +48,31 @@ printf "\n"
 mic_card=$(aplay -l | grep "card ${mic_card_num}" | head -n 1 | tr -s ' ' | cut -d' ' -f3)
 rig_card=$(aplay -l | grep "card ${rig_card_num}" | head -n 1 | tr -s ' ' | cut -d' ' -f3)
 
-echo $mic_card
-echo $rig_card
+printf "mic_card: %s rig_card:\n" $mic_card $rig_card
 
 # clean up any processes if we get a ctrl-C
 trap clean_up SIGHUP SIGINT SIGTERM
 
 tx=0
+ssb=0
 key=' ' 
 while [[ ! $key == "q" ]]
 do
+    printf "\n****************************************************\n"
+    printf "tx: %d ssb: %d Quit-q Toggle Tx-spacebar Toggle SSB-s\n" $tx $ssb
+    printf "****************************************************\n"
     read -N 1 key
-    echo $key
+    # space char doesn't compare well
     key=${key/ /t}
+
+    if [ $key == "s" ]; then
+        if [ $ssb -eq 1 ]; then
+            ssb=0
+        else
+            ssb=1
+        fi
+    fi
+
     if [ "$key" == "t" ]; then
         if [ $tx -eq 1 ]; then
             tx=0
@@ -59,7 +82,11 @@ do
             echo
         else
             tx=1
-            kick_off_tx_process
+            if [ $ssb -eq 0 ]; then
+                kick_off_radae_tx_process
+            else
+                kick_off_ssb_tx_process
+            fi
         fi
     fi
 done

--- a/ptt_test.sh
+++ b/ptt_test.sh
@@ -1,22 +1,42 @@
 #!/bin/bash
+#
+# Script based console RADAE application for sending RADAE over a SSB radio
+#
+# Scope: This is not production software.  It is designed for the Linux user who is comfortable 
+# experimenting/modifying this script to get it running on their station.  The goal is just enough
+# functionality to try real time RADAE contacts over the air.
+#
+# Notes:
+#   1. Set up ptt_test.conf
+#   2. t to start/stop transmitting
+#   3. r to start/stop receiving
+#   4. When idle, press S to enter SSB mode (audio piped through).
+#   5. Note SSB Tx won't be compressed unless you use the radios compressor
+#   6. Note radios Tx compressor should be off RADAE Tx (clean audio path)
+#   7. To listen from a KiwSDR
+#      sudo modprobe snd-aloop
+#      Open your Settings, and select the loopback device this was obscurely labelled "Analog Output - Built in Audio" on my machine.
+#      In ptt_test.conf use the Loopback dev# for rig_out_card_num, and rig_out_dev 1 
 
-# Hamlib rigctl model, change by seeting an env variable
-model=${model:-3061}
-serial=${serial:-"/dev/ttyUSB0"}
-echo $model
-echo $serial
+# Hamlib rigctl model and serial port, change by setting an env variable
+conf=${conf:-"ptt_test.conf"}
+model=$(cat $conf | grep "rigctl_model" | tr -s ' ' | cut -d' ' -f2)
+serial=$(cat $conf | grep "serial_port" | tr -s ' ' | cut -d' ' -f2)
 
 function clean_up {
+    run_rigctl "\\set_ptt 0" $model
     echo "killing Tx process"
     kill `cat tx_pid`
     wait ${tx_pid} 2>/dev/null
-    run_rigctl "\\set_ptt 0" $model
+    echo "killing Rx process"
+    kill `cat rx_pid`
+    wait ${tx_pid} 2>/dev/null
     exit 1
 }
 
 function kick_off_ssb_tx_process {
     ( arecord --device "plughw:CARD=${mic_card},DEV=0" -f S16_LE -c 1 -r 8000 & echo $! >tx_pid ) | \
-    aplay -f S16_LE --device "plughw:CARD=${rig_card},DEV=0" &
+    aplay -f S16_LE --device "plughw:CARD=${rig_in_card},DEV=0" &
 
     echo
     echo "Starting SSB transmitter...."
@@ -29,12 +49,35 @@ function kick_off_radae_tx_process {
     ( arecord --device "plughw:CARD=${mic_card},DEV=0" -f S16_LE -c 1 -r 16000 & echo $! >tx_pid ) | \
     ./build/src/lpcnet_demo -features - - | \
     python3 radae_tx.py model19_check3/checkpoints/checkpoint_epoch_100.pth --auxdata | \
-    python3 f32toint16.py --real --scale 8192 | aplay -f S16_LE --device "plughw:CARD=${rig_card},DEV=0" &
+    python3 f32toint16.py --real --scale 8192 | aplay -f S16_LE --device "plughw:CARD=${rig_in_card},DEV=0" &
 
     echo
     echo "Starting RADAE transmitter...."
     echo
     cat tx_pid
+}
+
+function kick_off_radae_rx_process {
+    ( arecord --device "plughw:CARD=${rig_out_card},DEV=${rig_out_card_dev}" -f S16_LE -c 1 -r 8000 & echo $! >rx_pid ) | \
+    python3 int16tof32.py --zeropad | \
+    python3 radae_rx.py model19_check3/checkpoints/checkpoint_epoch_100.pth -v 2 --auxdata | \
+    ./build/src/lpcnet_demo -fargan-synthesis - - | \
+    aplay -f S16_LE -r 16000 --device "plughw:CARD=${speaker_card},DEV=0" &
+
+    echo
+    echo "Starting RADAE receiver...."
+    echo
+    cat rx_pid
+}
+
+function kick_off_ssb_rx_process {
+    ( arecord --device "plughw:CARD=${rig_out_card},DEV=${rig_out_card_dev}" -f S16_LE -c 1 -r 8000 & echo $! >rx_pid ) | \
+    aplay -f S16_LE -r 8000 --device "plughw:CARD=${speaker_card},DEV=0" &
+
+    echo
+    echo "Starting SSB receiver...."
+    echo
+    cat rx_pid
 }
 
 function run_rigctl {
@@ -47,44 +90,59 @@ function run_rigctl {
     fi
 }
 
-# Set sounds cards every time we start as they may change
-
-echo "---------------------"
-echo "Available audio cards"
-echo "---------------------"
+echo "---------------------------------"
+echo "Available audio cards and devices"
+echo "---------------------------------"
 echo 
 
 aplay -l | grep card
 
-printf "\nselect mic card number......: "
-read -N 1 mic_card_num
-printf "\nselect rig input card number: "
-read -N 1 rig_card_num
-printf "\n"
+echo 
+echo "---------------------------------"
+echo "Loading ${conf}"
+echo "---------------------------------"
+echo 
+
+mic_card_num=$(cat $conf | grep "mic_card_num" | tr -s ' ' | cut -d' ' -f2)
+mic_card_dev=$(cat $conf | grep "mic_card_dev" | tr -s ' ' | cut -d' ' -f2)
+rig_in_card_num=$(cat $conf | grep "rig_in_card_num" | tr -s ' ' | cut -d' ' -f2)
+rig_in_card_dev=$(cat $conf | grep "rig_in_card_dev" | tr -s ' ' | cut -d' ' -f2)
+rig_out_card_num=$(cat $conf | grep "rig_out_card_num" | tr -s ' ' | cut -d' ' -f2)
+rig_out_card_dev=$(cat $conf | grep "rig_out_card_dev" | tr -s ' ' | cut -d' ' -f2)
+speaker_card_num=$(cat $conf | grep "speaker_card_num" | tr -s ' ' | cut -d' ' -f2)
+speaker_card_dev=$(cat $conf | grep "speaker_card_dev" | tr -s ' ' | cut -d' ' -f2)
 
 mic_card=$(aplay -l | grep "card ${mic_card_num}" | head -n 1 | tr -s ' ' | cut -d' ' -f3)
-rig_card=$(aplay -l | grep "card ${rig_card_num}" | head -n 1 | tr -s ' ' | cut -d' ' -f3)
+rig_in_card=$(aplay -l | grep "card ${rig_in_card_num}" | head -n 1 | tr -s ' ' | cut -d' ' -f3)
+rig_out_card=$(aplay -l | grep "card ${rig_out_card_num}" | head -n 1 | tr -s ' ' | cut -d' ' -f3)
+speaker_card=$(aplay -l | grep "card ${speaker_card_num}" | head -n 1 | tr -s ' ' | cut -d' ' -f3)
 
-printf "mic_card: %s rig_card:\n" $mic_card $rig_card
+printf "rigctl_model: %d\n" $model
+printf "serial_port.: %s\n" $serial
+
+printf "mic....: %d: %-10s device %d\n" $mic_card_num $mic_card $mic_card_dev
+printf "rig_in.: %d: %-10s device %d\n" $rig_in_card_num  $rig_in_card $rig_in_card_dev
+printf "rig_out: %d: %-10s device %d\n" $rig_out_card_num $rig_out_card $rig_out_card_dev
+printf "speaker: %d: %-10s device %d\n" $speaker_card_num $speaker_card $speaker_card_dev
 
 # clean up any processes if we get a ctrl-C
 trap clean_up SIGHUP SIGINT SIGTERM
 
+rx=0
 tx=0
 ssb=0
 key=' ' 
 while [[ ! $key == "q" ]]
 do
-    printf "\n****************************************************\n"
-    printf "tx: %d ssb: %d Quit-q Toggle Tx-spacebar Toggle SSB-s\n" $tx $ssb
-    printf "****************************************************\n"
+    printf "\n***************************************************************\n"
+    printf "tx: %d rx: %d ssb: %d Quit-q Toggle Tx-t Toggle Rx-r Toggle SSB-s\n" $tx $rx $ssb
+    printf "***************************************************************\n"
     read -N 1 key
-    # space char doesn't compare well
-    key=${key/ /t}
 
     # toggle SSB/RADAE
-    if [ $key == "s" ]; then
-        if [ $ssb -eq 1 ]; then
+    if [ "$key" == "s" ]; then
+        echo "toggle SSB"
+        if [ "$ssb" -eq 1 ]; then
             ssb=0
         else
             ssb=1
@@ -101,6 +159,9 @@ do
             echo
             run_rigctl "\\set_ptt 0" $model
         else
+            if [ $rx -eq 1 ]; then
+                kill `cat rx_pid`
+            fi
             tx=1
             if [ $ssb -eq 0 ]; then
                 kick_off_radae_tx_process
@@ -108,6 +169,28 @@ do
                 kick_off_ssb_tx_process
             fi
             run_rigctl "\\set_ptt 1" $model
+        fi
+    fi
+
+    # toggle receive
+    if [ "$key" == "r" ]; then
+        if [ $rx -eq 1 ]; then
+            rx=0
+            kill `cat rx_pid`
+            echo
+            echo 'Rx stopped!'
+            echo
+         else
+            if [ $tx -eq 1 ]; then
+                kill `cat tx_pid`
+                run_rigctl "\\set_ptt 0" $model
+            fi
+            rx=1
+            if [ $ssb -eq 0 ]; then
+                kick_off_radae_rx_process
+            else
+                kick_off_ssb_rx_process
+            fi
         fi
     fi
 done

--- a/ptt_test.sh
+++ b/ptt_test.sh
@@ -1,12 +1,34 @@
 #!/bin/bash
 
+function clean_up {
+    echo "killing Tx process"
+    kill `cat tx_pid`
+    wait ${tx_pid} 2>/dev/null
+    exit 1
+}
+
+function kick_off_tx_process {
+    arecord --device "plughw:CARD=${mic_card},DEV=0" -f S16_LE -c 1 -r 16000 | \
+    ./build/src/lpcnet_demo -features - - | \
+    ( python3 radae_tx.py model19_check3/checkpoints/checkpoint_epoch_100.pth --auxdata & echo $! >tx_pid ) | \
+    python3 f32toint16.py --real --scale 8192 | aplay -f S16_LE --device "plughw:CARD=${rig_card},DEV=0" &
+
+    echo
+    echo "RADAE transmitter running!  Any key to exit"
+    echo
+    cat tx_pid
+}
+
+# Set sounds cards every time we start as they may change
+
 echo "---------------------"
 echo "Available audio cards"
-echo "---------------------\n"
+echo "---------------------"
+echo 
 
 aplay -l | grep card
 
-printf "\nselect mic card number: "
+printf "\nselect mic card number......: "
 read -N 1 mic_card_num
 printf "\nselect rig input card number: "
 read -N 1 rig_card_num
@@ -18,9 +40,31 @@ rig_card=$(aplay -l | grep "card ${rig_card_num}" | head -n 1 | tr -s ' ' | cut 
 echo $mic_card
 echo $rig_card
 
-arecord --device "plughw:CARD=${mic_card},DEV=0" -f S16_LE -c 1 -r 16000 | \
-./build/src/lpcnet_demo -features - - | \
-python3 radae_tx.py model19_check3/checkpoints/checkpoint_epoch_100.pth --auxdata | \
-python3 f32toint16.py --real --scale 8192 | aplay -f S16_LE --device "plughw:CARD=${rig_card},DEV=0"
+# clean up any processes if we get a ctrl-C
+trap clean_up SIGHUP SIGINT SIGTERM
 
-echo "RADAE transmitter running!  Ctrl-C to exit"
+tx=0
+key=' ' 
+while [[ ! $key == "q" ]]
+do
+    read -N 1 key
+    echo $key
+    key=${key/ /t}
+    if [ "$key" == "t" ]; then
+        if [ $tx -eq 1 ]; then
+            tx=0
+            kill `cat tx_pid`
+            echo
+            echo 'Tx stopped!'
+            echo
+        else
+            tx=1
+            kick_off_tx_process
+        fi
+    fi
+done
+
+if [ $tx -eq 1 ]; then
+  kill `cat tx_pid`
+fi
+

--- a/radae/dsp.py
+++ b/radae/dsp.py
@@ -200,7 +200,7 @@ class acquisition():
       Dt1 = np.zeros((len(tfine_range),len(ffine_range)), dtype=np.csingle)
       Dt2 = np.zeros((len(tfine_range),len(ffine_range)), dtype=np.csingle)
       t_ind = 0
-      tmax_ind = tmax
+      tmax_ind = 0
       Dtmax = 0
 
       for t in tfine_range:

--- a/radae/dsp.py
+++ b/radae/dsp.py
@@ -200,6 +200,7 @@ class acquisition():
       Dt1 = np.zeros((len(tfine_range),len(ffine_range)), dtype=np.csingle)
       Dt2 = np.zeros((len(tfine_range),len(ffine_range)), dtype=np.csingle)
       t_ind = 0
+      tmax_ind = tmax
       Dtmax = 0
 
       for t in tfine_range:

--- a/test/chirp_mpp.sh
+++ b/test/chirp_mpp.sh
@@ -16,6 +16,8 @@ No=$2
 chirp_duration=4
 silence_duration=3
 
+which ${CODEC2_DEV_BUILD_DIR}/src/ch >/dev/null || { printf "\n**** Can't find ch - check CODEC2_PATH **** \n\n"; exit 1; }
+
 source test/make_g.sh
 cp -f g_mpp.f32 fast_fading_samples.float
 chirp_f32=$(mktemp)


### PR DESCRIPTION
Following on from #14, various tasks including Linux command line/script based real time RADAE to get early experience in PTT operation.

- [x] real time command line KiwiSDR RADAE Rx: KiwiSDR->RADAE Rx->speakers
- [ ] stored file processing using file names with spaces
- [x] real time SSB Radio RADAE Tx: mic->RADAE Tx->SSB radio, plus PTT using `rigctl`
- [x] real time SSB Radio RADAE Rx:  SSB Radio->RADAE Rx->speakers
- [x] way to flip between SSB and RADAE on Rx, e.g. reconfigure pulse audio. Problem here is SSB speech compressor on Tx, needs to be off for RADAE, on for SSB to make a fair comparison.  Can this be controlled by `rigctl`.
- [x] script based RADAE Tx/Rx, e.g. hit space bar to Tx, manual config of sound devices on cmd line, just enough to have a real time OTA QSO.
