### PR TITLE
Reset decoder states on resync

### DIFF
--- a/radae/dsp.py
+++ b/radae/dsp.py
@@ -402,7 +402,7 @@ class receiver_one():
 
       # est ampl across one just two sets of pilots seems to work OK (loss isn't impacted)
       if self.coarse_mag:
-         mag = torch.mean(torch.abs(rx_pilots)**2)**0.5
+         mag = torch.mean(torch.abs(rx_pilots)**2)**0.5 + 1E-6
          if self.bottleneck == 3:
             mag = mag*torch.abs(self.P[0])/self.pilot_gain
          #print(f"coarse mag: {mag:f}", file=sys.stderr)

--- a/radae/radae.py
+++ b/radae/radae.py
@@ -118,9 +118,13 @@ class GRUStatefull(nn.Module):
         self.hidden_dim = hidden_dim
         self.states = torch.zeros(1,1,self.hidden_dim)
         self.gru = nn.GRU(input_dim, hidden_dim, batch_first=batch_first)
+
     def forward(self, x):
         gru_out,self.states = self.gru(x,self.states)
         return gru_out
+
+    def reset(self):
+       self.states = torch.zeros(1,1,self.hidden_dim)
 
 # Wrapper for conv1D layer that maintains state internally
 class Conv1DStatefull(nn.Module):
@@ -139,6 +143,9 @@ class Conv1DStatefull(nn.Module):
         self.states = conv_in[:,-self.states_len:,:]
         conv_in = conv_in.permute(0, 2, 1)
         return torch.tanh(self.conv(conv_in)).permute(0, 2, 1)
+
+    def reset(self):
+        self.states = torch.zeros(1,self.states_len,self.input_dim)
 
 #Gated Linear Unit activation
 class GLU(nn.Module):
@@ -427,6 +434,20 @@ class CoreDecoderStatefull(nn.Module):
         features = torch.reshape(x,(1,z.shape[1]*self.FRAMES_PER_STEP,self.output_dim))
         return features
 
+    def reset(self):
+        self.conv1.reset()
+        self.conv2.reset()
+        self.conv3.reset()
+        self.conv4.reset()
+        self.conv5.reset()
+
+        self.gru1.reset()
+        self.gru1.reset()
+        self.gru2.reset()
+        self.gru3.reset()
+        self.gru4.reset()
+        self.gru5.reset()
+        
 class RADAE(nn.Module):
     def __init__(self,
                  feature_dim,

--- a/radae_rxe.py
+++ b/radae_rxe.py
@@ -140,7 +140,7 @@ class radae_rx:
                  
    def get_sync(self):
       return self.state == "sync"
-                 
+              
    def do_radae_rx(self, buffer_complex, features_out):
       acq = self.acq
       bpf = self.bpf
@@ -247,6 +247,7 @@ class radae_rx:
                self.valid_count = self.valid_count + 1
                if self.valid_count > 3:
                   next_state = "sync"
+                  model.core_decoder_statefull.module.reset()
                   self.synced_count = 0
                   uw_fail = False
                   if auxdata:


### PR DESCRIPTION
During alpha testing of freedv-gui + RADE Mooneer and Walter reporting a howling sound from decoder that could be reset by re-initialing RADE.  This may be due to the decoder being kicked into bad states where it gets stuck. As a precaution, this PR resets the decoder states on re-sync.

TODO

- [x] Any other states in Rx we should reset, e.g. classical DSP code in `dsp.py`? Does anything go crazy when it gets zeros fed into it?
- [x] Can we reproduce the problem from the command line?
- [x] It's possible a set of inputs not seen in training could push the network into an undefined state, either on the tx (a certain speaker) or rx (certain channel noise) side.  We should be able to trap that with an example.
- [ ] Can we reset the FARGAN decoder states (external C library)?
- [ ] (tmiw) Fix gap-in-rx-audio dropped sample bug in freedv-gui