### PR TITLE
add workaround for OpenBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,14 @@ else(NOT CMAKE_CROSSCOMPILING)
     endif(WIN32)
 endif(NOT CMAKE_CROSSCOMPILING)
 
+# OpenBSD's libpython requires libintl but its path is not provided
+# by pkg-config. This is workaround.
+if(${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
+    find_package(Intl REQUIRED)
+    get_filename_component(INTL_LIBDIR ${Intl_LIBRARY} DIRECTORY)
+    link_directories(${INTL_LIBDIR})
+endif()
+
 add_subdirectory(src)
 
 # Ctests ----------------------------------------------------------------------


### PR DESCRIPTION
I could build radae on OpenBSD. Adding a workaround to CMakeLists.txt and some environment variables are required.

```
$ export MAKE=gmake
$ export AUTOMAKE_VERSION=1.16
$ export AUTOCONF_VERSION=2.69
$ mkdir build
$ cd build
$ cmake ..
$ gmake
```

Currently xiph/opus is non-GNU tar unfriendly, need to wait [this fix](https://github.com/xiph/opus/pull/398) will be applied.
