### PR TITLE
Disable Python GC on rade_start().

### DIFF
--- a/src/rade_api.c
+++ b/src/rade_api.c
@@ -345,6 +345,14 @@ struct rade *rade_open(char model_file[], int flags) {
   // Acquire the Python GIL (needed for multithreaded use)
   PyGILState_STATE gstate = PyGILState_Ensure();
 
+  // Did you know that Python 3.10+ has a garbage collector?
+  // That isn't good for real-time audio, so disable it while
+  // RADE is running.
+#if (PY_MAJOR_VERSION > 3) || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 10)
+  int prevGcState = PyGC_Disable();
+  fprintf(stderr, "Python garbage collector disabled (previous state %d)\n", prevGcState);
+#endif // (PY_MAJOR_VERSION > 3) || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 10)
+
   // TODO: implement me
   fprintf(stderr, "model file: %s\n", model_file);
 


### PR DESCRIPTION
Turns out that [Python has a garbage collector](https://docs.python.org/3/c-api/gcsupport.html). We don't want it running at random times and causing real-time threads in the system to miss deadlines as a result, so this PR causes it to be disabled when `rade_open()` is called.

Note: Python still uses reference counting but this should be more deterministic than using the garbage collector. And of course, once RADE is fully ported to C this won't be necessary.