### PR TITLE
Use GitHub version of Opus to work around CI failures.

### DIFF
--- a/cmake/BuildOpus.cmake
+++ b/cmake/BuildOpus.cmake
@@ -6,7 +6,9 @@ if (CMAKE_CROSSCOMPILING)
 set(CONFIGURE_COMMAND ${CONFIGURE_COMMAND} --host=${CMAKE_C_COMPILER_TARGET} --target=${CMAKE_C_COMPILER_TARGET})
 endif (CMAKE_CROSSCOMPILING)
 
+if (NOT DEFINED OPUS_URL)
 set(OPUS_URL https://github.com/xiph/opus/archive/refs/heads/main.zip)
+endif (NOT DEFINED OPUS_URL)
 
 include(ExternalProject)
 if(APPLE AND BUILD_OSX_UNIVERSAL)

--- a/cmake/BuildOpus.cmake
+++ b/cmake/BuildOpus.cmake
@@ -6,7 +6,7 @@ if (CMAKE_CROSSCOMPILING)
 set(CONFIGURE_COMMAND ${CONFIGURE_COMMAND} --host=${CMAKE_C_COMPILER_TARGET} --target=${CMAKE_C_COMPILER_TARGET})
 endif (CMAKE_CROSSCOMPILING)
 
-set(OPUS_URL https://gitlab.xiph.org/xiph/opus/-/archive/main/opus-main.tar.gz)
+set(OPUS_URL https://github.com/xiph/opus/archive/refs/heads/main.zip)
 
 include(ExternalProject)
 if(APPLE AND BUILD_OSX_UNIVERSAL)


### PR DESCRIPTION
GitHub Actions for freedv-gui clones this repo during builds of its supported platforms (which in turn clones the Opus repo during its build). Unfortunately, `gitlab.xiph.org` has been having problems as of late (and/or is actively throttling/blocking GitHub) so this PR switches the Opus build to use the GitHub mirror of Opus instead.