### PR TITLE
Enable OSCE/BBWENet support in Opus.

### DIFF
--- a/cmake/BuildOpus.cmake
+++ b/cmake/BuildOpus.cmake
@@ -1,6 +1,6 @@
 message(STATUS "Will build opus with FARGAN")
 
-set(CONFIGURE_COMMAND ./autogen.sh && ./configure --enable-dred --disable-shared --disable-doc --disable-extra-programs)
+set(CONFIGURE_COMMAND ./autogen.sh && ./configure --enable-osce --enable-dred --disable-shared --disable-doc --disable-extra-programs)
 
 if (CMAKE_CROSSCOMPILING)
 set(CONFIGURE_COMMAND ${CONFIGURE_COMMAND} --host=${CMAKE_C_COMPILER_TARGET} --target=${CMAKE_C_COMPILER_TARGET})


### PR DESCRIPTION
Adds `--enable-osce` to Opus configuration to ensure that we can use BBWENet.