### PR TITLE
add ASR test scripts and WER plot functions from dr-asr

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,38 @@ This section is optional - pre-trained models that run on a standard laptop CPU 
    ```
 
 
+# ASR Tests
+
+Automatic Speech Recognition (ASR) is used as an objective speech quality metric to compare RADE V1 against SSB and FreeDV 700D. The [Whisper](https://github.com/openai/whisper) ASR model scores Word Error Rate (WER) on LibriSpeech samples passed through the modems under test.
+
+1. Install dependencies:
+   ```
+   pip3 install jiwer openai-whisper
+   ```
+
+1. Run controls (clean speech, FARGAN vocoder only, 4 kHz bandwidth):
+   ```
+   ./asr_test.sh clean && ./asr_test.sh fargan && ./asr_test.sh 4kHz
+   ```
+
+1. Run a sweep across AWGN channel conditions for each mode (100 samples):
+   ```
+   ./asr_test_top.sh ssb -n 100
+   ./asr_test_top.sh rade -n 100
+   ./asr_test_top.sh 700D -n 100
+   ```
+
+1. For MPP channel, first generate fading samples (if not already present), then re-run with `--g_file`:
+   ```
+   ./test/make_g.sh
+   ./asr_test_top.sh rade -n 100 --g_file g_mpp.f32
+   ```
+
+1. Plot WER curves in Octave:
+   ```
+   octave:1> radae_plots; plot_wer("241221","241221_asr_test.png")
+   ```
+
 # C Port of Core Encoder and Decoder
 
 The following describes the V1 C port.  A V2 C port is planned as future work.

--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ Automatic Speech Recognition (ASR) is used as an objective speech quality metric
    pip3 install jiwer openai-whisper
    ```
 
+1. The LibriSpeech `test-clean` dataset (~400 MB) is downloaded automatically to `~/.cache/LibriSpeech/` on first run via `torchaudio`.
+
 1. Run controls (clean speech, FARGAN vocoder only, 4 kHz bandwidth):
    ```
    ./asr_test.sh clean && ./asr_test.sh fargan && ./asr_test.sh 4kHz

--- a/asr_test.sh
+++ b/asr_test.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# asr_test.sh
+#
+# Automatic Speech Recognition (ASR) testing for the  Radio Autoencoder. This script
+# takes the samples from a clean dataset (e.g. Librispeech test-clean), and generates
+# a dataset with channel simulations (RADE, SSB etc) applied.
+
+CODEC2_DEV=${CODEC2_DEV:-${HOME}/codec2-dev}
+PATH=${PATH}:${CODEC2_DEV}/build_linux/src:${CODEC2_DEV}/build_linux/misc:${PWD}/build/src
+
+which ch >/dev/null || { printf "\n**** Can't find ch - check CODEC2_PATH **** \n\n"; exit 1; }
+
+source utils.sh
+
+function print_help {
+    echo
+    echo "Automated Speech Recognition (ASR) dataset processing for Radio Autoencoder testing"
+    echo
+    echo "  usage ./asr_test.sh ssb|rade|700D|fargan|4kHz [test option below]"
+    echo "  usage ./ota_test.sh ssb --No -30"
+    echo "  usage ./ota_test.sh rade --EbNodB 10"
+    echo
+    echo "    --EbNodB EbNodB           inference.py simulation noise level (experiment to get desired SNR)"
+    echo "    --No NodB                 ch channel simulation No value (experiment to get desired SNR)"
+    echo "    -n numSamples             number of dataset samples to process (default all)"
+    echo "    --results resultsFile     name of results file (deafult results.txt)"
+    echo "    -d                        verbose debug information"
+    exit
+}
+
+n_samples=0
+No=-100
+EbNodB=100
+setpoint_rms=2048
+comp_gain=6
+results=asr_results.txt
+inference_args=""
+ch_args=""
+sil=0.5
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+key="$1"
+case $key in
+    --EbNodB)
+        EbNodB="$2"
+        shift
+        shift
+    ;;
+    --g_file)
+        g_file="$2"
+        if [ ! -f $2 ]; then
+            echo "can't find $2"
+            exit 1
+        fi
+        inference_args="${inference_args} --g_file ${2}"
+        cp ${2} fast_fading_samples.float	
+        ch_args="${ch_args} --fading_dir . --mpp --gain 0.5"
+        shift
+        shift
+    ;;
+    --No)
+        No="$2"
+        shift
+        shift
+    ;;
+    --results)
+        results="$2"
+        shift
+        shift
+    ;;
+    -n)
+        n_samples="$2"
+        shift
+        shift
+    ;;
+    -d)
+        set -x;
+        shift
+    ;;
+    -h)
+        print_help	
+    ;;
+    *)
+    POSITIONAL+=("$1") # save it in an array for later
+    shift
+    ;;
+esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
+if [ $# -lt 1 ]; then
+    print_help
+fi
+mode=$1
+
+source=~/.cache/LibriSpeech/test-clean
+if [ ! -d $source ]; then
+  echo "cant find Librispeech source directory" $source
+  exit 1 
+fi
+# results must be written to a directory known by Librispeech package (can't be any name)
+dest=~/.cache/LibriSpeech/test-other
+rm -Rf $dest
+
+# cp translation files to new dataset directory
+function cp_translation_files {
+    pushd $source > /dev/null; trans=$(find . -name '*.txt'); popd  > /dev/null
+    for f in $trans
+    do
+        d=$(dirname $f)
+        mkdir -p ${dest}/${d}
+        cp ${source}/${f} ${dest}/${f}
+    done
+}
+
+function print_mean_text_file {
+    file_name=$1
+    python3 - <<END
+import numpy as np
+s=np.loadtxt("${file_name}")
+print(f"{np.mean(s):5.2f}", end='')
+END
+}
+
+# process audio files and place in new dataset directory
+function process {
+    pushd $source > /dev/null; flac=$(find . -name '*.flac'); popd > /dev/null
+    if [ $n_samples -ne 0 ]; then
+        flac=$(echo "$flac" | shuf --random-source=<(yes 42) | head -n $n_samples)
+    fi
+
+    n=$(echo "$flac" | wc -l)
+    printf "Processing %d samples in dataset\n" $n
+
+    in=in.raw
+    comp=comp.raw
+    ch_log=ch_log.txt
+    rade_log=rade_log.txt
+    snr_log=snr_log.txt
+    asr_log=asr.txt
+    rm -f ${snr_log}
+    CNo_log=CNo_log.txt
+    rm -f ${CNo_log}
+    sox -n -r 16000 -c 1 /tmp/silence.wav trim 0.0 ${sil}
+
+    if [ $mode == "ssb" ] || [ $mode == "4kHz" ]; then
+        
+        fading_adv=0
+        for f in $flac
+        do
+            d=$(dirname $f)
+            mkdir -p ${dest}/${d}
+
+            if [ $mode == "ssb" ]; then
+                sox ${source}/${f} -t .s16 -r 8000 ${in}
+                # AGC and Hilbert compression
+                set_rms ${in} $setpoint_rms
+                analog_compressor  ${in} ${comp} ${comp_gain} 2>/dev/null
+                ch ${comp} - --No ${No} ${ch_args} --fading_adv ${fading_adv} 2>${ch_log} | sox -t .s16 -r 8000 -c 1 - -r 16000 ${dest}/${f}
+                grep "Fading file finished" $ch_log
+                if [ $? -eq 0 ]; then
+                    echo "Error - fading file too short after" $fading_adv " seconds"
+                    exit 1
+                fi
+                snr=$(cat $ch_log | grep "SNR3k" | tr -s ' ' | cut -d' ' -f3)
+                CNo=$(cat $ch_log | grep "SNR3k" | tr -s ' ' | cut -d' ' -f5)
+                echo $snr >> ${snr_log}
+                echo $CNo >> ${CNo_log}
+
+                # advance through fading simulation file
+                dur=$(sox --info -D ${source}/${f})
+                fading_adv=$(python3 -c "print(${fading_adv} + ${dur})")
+            else
+              # $mode == "4kHz" (4kHz bandwidth, representing ideal Fs=8kHz vocoder)
+              sox ${source}/${f} -r 8000 -t .s16 -c 1 - | sox -r 8000 -t .s16 -c 1 - -r 16000 ${dest}/${f}
+            fi
+        done
+        if [ $mode == "ssb" ]; then
+          SNR_mean=$(print_mean_text_file ${snr_log})
+          CNo_mean=$(print_mean_text_file ${CNo_log})
+        fi
+    fi
+    
+    if [ $mode == "700D" ]; then
+        
+        fading_adv=0
+        for f in $flac
+        do
+            d=$(dirname $f)
+            mkdir -p ${dest}/${d}
+
+            # silence either side of sample to allow time for acquisition and latency
+            sox /tmp/silence.wav /tmp/silence.wav ${source}/${f} /tmp/silence.wav -t .s16 -r 8000 ${in}
+
+            # trim start to remove acquisition noise
+            freedv_tx 700D ${in} - | \
+            ch - - --No ${No} ${ch_args} --fading_adv ${fading_adv} 2>${ch_log} | \
+            freedv_rx 700D - out.raw 2>/dev/null
+            cat out.raw | sox -t .s16 -r 8000 -c 1 - -r 16000 ${dest}/${f} trim 0.5
+            # error check
+            grep "Fading file finished" $ch_log
+            if [ $? -eq 0 ]; then
+                echo "Error - fading file too short after" $fading_adv " seconds"
+                exit 1
+            fi
+            snr=$(cat $ch_log | grep "SNR3k" | tr -s ' ' | cut -d' ' -f3)
+            CNo=$(cat $ch_log | grep "SNR3k" | tr -s ' ' | cut -d' ' -f5)
+            echo $snr >> ${snr_log}
+            echo $CNo >> ${CNo_log}
+
+            # advance through fading simulation file
+            dur=$(sox --info -D ${source}/${f})
+            fading_adv=$(python3 -c "print(${fading_adv} + ${dur})")
+
+        done
+        SNR_mean=$(print_mean_text_file ${snr_log})
+        CNo_mean=$(print_mean_text_file ${CNo_log})
+    fi
+
+    if [ $mode == "rade" ] || [ $mode == "fargan" ]; then
+        # find length of each file
+        duration_log=""
+        flac_full=""
+        pushd $source > /dev/null;
+        for f in $flac
+        do
+          duration_log+=$(sox --info -D ${f})
+          duration_log+=" "
+          flac_full+="${source}/${f} /tmp/silence.wav "
+        done
+        popd > /dev/null; 
+        
+        # cat samples into one long input file, insert 500ms at end of sample to allow for processing at output
+        sox $flac_full -t .s16 ${in}
+
+        # process all samples as one file to save time
+
+        if [ $mode == "rade" ]; then
+            ./inference.sh model19_check3/checkpoints/checkpoint_epoch_100.pth ${in} out.wav \
+            --rate_Fs --pilots --pilot_eq --eq_ls --cp 0.004 --bottleneck 3 --auxdata  --time_offset -16 \
+            --EbNodB $EbNodB ${inference_args} | tee ${rade_log}
+            grep "Multipath Doppler spread file too short" $rade_log
+            if [ $? -eq 0 ]; then
+                echo "Error - fading file too short"
+                exit 1
+            fi
+
+            SNR_mean=$(cat $rade_log | grep "Measured" | tr -s ' ' | cut -d' ' -f4)
+            CNo_mean=$(cat $rade_log | grep "Measured" | tr -s ' ' | cut -d' ' -f3)
+        else
+            # $mode == "fargan"
+            ./inference.sh model19_check3/checkpoints/checkpoint_epoch_100.pth ${in} out.wav --auxdata --passthru
+            #sox -t .s16 -r 16000 -c 1 ${in} out.wav
+        fi
+
+        # extract individual output files
+        duration_array=( ${duration_log} )
+        i=0
+        st=0
+        for f in $flac
+        do
+          dur=${duration_array[i]}
+          dur=$(python3 -c "print($dur + ${sil})")
+          #printf "%4d %s %5.2f %5.2f\n" $i $f $st $dur
+          ((i++))
+          if [ $i -eq ${#duration_array[@]} ]; then
+            sox out.wav ${dest}/${f} trim $st
+          else
+            sox out.wav ${dest}/${f} trim $st $dur
+          fi
+          st=$(python3 -c "print($st + $dur)")
+        done
+    fi
+
+    # test mode that just copies files
+    if [ $mode == "clean" ]; then
+        for f in $flac
+        do
+          cp ${source}/${f} ${dest}/${f}
+        done
+        
+    fi
+
+    python3 asr_wer.py test-other -n $n_samples --model turbo | tee > $asr_log
+    wer=$(tail -n1 $asr_log | tr -s ' ' | cut -d' ' -f2)
+    if [ $mode == "ssb" ] || [ $mode == "rade" ] || [ $mode == "700D" ]; then
+      printf "%-6s %5.2f %5.2f %5.2f\n" $mode $SNR_mean $CNo_mean $wer | tee -a $results
+    else
+      printf "%-6s %5.2f\n" $mode $wer | tee -a $results
+    fi
+}
+
+cp_translation_files
+process
+

--- a/asr_test_top.sh
+++ b/asr_test_top.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# asr_test_awgn.sh
+#
+# Top level ASR test script for AWGN and MPP channels
+set -x
+results_file=241221_asr
+n=500
+
+function ssb {
+    local results_file=$1
+    No_range=$2
+    for No in $No_range
+    do
+        ./asr_test.sh ssb --No $No -n $n --results ${results_file} $3
+    done
+    cat ${results_file} | grep ssb | sed -e "s/ssb//" > tmp.txt 
+    mv tmp.txt ${results_file}
+}
+
+function rade {
+    local results_file=$1
+    EbNodB_range=$2
+    for EbNodB in $EbNodB_range
+    do
+        ./asr_test.sh rade --EbNodB $EbNodB -n $n --results ${results_file} $3
+    done
+    cat ${results_file} | grep rade | sed -e "s/rade//" > tmp.txt
+    mv tmp.txt ${results_file}
+}
+
+function freedv_700D {
+    local results_file=$1
+    No_range=$2
+    for No in $No_range
+    do
+        ./asr_test.sh 700D --No $No -n $n --results ${results_file} $3
+    done
+    cat ${results_file} | grep 700D | sed -e "s/700D//" > tmp.txt 
+    mv tmp.txt ${results_file}
+}
+
+freedv_700D ${results_file}_awgn_700D.txt  "-100 -30 -26 -23 -20 -17 -15 -13"
+freedv_700D ${results_file}_mpp_700D.txt   "-100 -39 -36 -33 -30 -27" "--g_file g_mpp.f32"
+#freedv_700D ${results_file}_awgn_700D.txt  "-100 -38 -35 -32 -29 -26 -23 -20 -17"
+#freedv_700D ${results_file}_mpp_700D.txt   "-100 -44 -39 -36 -33 -30 -27" "--g_file g_mpp.f32"
+exit 0
+
+# run the controls
+controls_file=${results_file}_controls.txt
+rm -f ${controls_file}
+./asr_test.sh clean -n $n --results ${controls_file}
+./asr_test.sh fargan -n $n --results ${controls_file}
+./asr_test.sh 4kHz -n $n --results ${controls_file}
+./asr_test.sh ssb -n $n --results ${controls_file}
+./asr_test.sh rade -n $n --results ${controls_file}
+# strip off all but last column for Octave plotting
+cat ${controls_file} | awk '{print $NF}' > ${results_file}_c.txt
+
+
+ssb  ${results_file}_awgn_ssb.txt  "-100 -38 -35 -32 -29 -26 -23 -20 -17"
+rade ${results_file}_awgn_rade.txt "100 15 10 5 2.5 0 -2.5"
+ssb  ${results_file}_mpp_ssb.txt   "-100 -44 -39 -36 -33 -30 -27" "--g_file g_mpp.f32"
+rade ${results_file}_mpp_rade.txt  "100 15 10 5 2.5 0" "--g_file g_mpp.f32"
+

--- a/asr_wer.py
+++ b/asr_wer.py
@@ -1,0 +1,91 @@
+# coding: utf-8
+
+# derived from: https://github.com/openai/whisper/blob/main/notebooks/LibriSpeech.ipynb
+
+import os,argparse
+import numpy as np
+import torch
+import pandas as pd
+import whisper
+import torchaudio
+from tqdm.notebook import tqdm
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+
+class LibriSpeech(torch.utils.data.Dataset):
+    """
+    A simple class to wrap LibriSpeech and trim/pad the audio to 30 seconds.
+    It will drop the last few seconds of a very small portion of the utterances.
+    """
+    def __init__(self, n_mels, split="test-clean", device=DEVICE):
+        self.dataset = torchaudio.datasets.LIBRISPEECH(
+            root=os.path.expanduser("~/.cache"),
+            url=split,
+            download=True,
+        )
+        self.device = device
+        self.n_mels = n_mels
+        print(n_mels)
+
+    def __len__(self):
+        return len(self.dataset)
+
+    def __getitem__(self, item):
+        audio, sample_rate, text, _, _, _ = self.dataset[item]
+        assert sample_rate == 16000
+        audio = whisper.pad_or_trim(audio.flatten()).to(self.device)
+        mel = whisper.log_mel_spectrogram(audio,n_mels=self.n_mels)
+        
+        return (mel, text)
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('test_name', type=str, help='Librispeech dataset name (e.g. test-clean)')
+parser.add_argument('-n', type=str, help='Number of dataset entries to use (default all of them)')
+parser.add_argument('--model', default='base.en',type=str, help='Whisper model')
+args = parser.parse_args()
+
+model = whisper.load_model(args.model)
+print(
+    f"Model is {'multilingual' if model.is_multilingual else 'English-only'} "
+    f"and has {sum(np.prod(p.shape) for p in model.parameters()):,} parameters."
+)
+# predict without timestamps for short-form transcription
+options = whisper.DecodingOptions(language="en", without_timestamps=True)
+
+dataset = LibriSpeech(model.dims.n_mels, args.test_name)
+if args.n:
+    dataset = torch.utils.data.Subset(dataset,list(range(0,int(args.n))))
+print("dataset length:", dataset.__len__())
+loader = torch.utils.data.DataLoader(dataset, batch_size=16)
+
+
+hypotheses = []
+references = []
+
+for mels, texts in loader:
+    results = model.decode(mels, options)
+    hypotheses.extend([result.text for result in results])
+    references.extend(texts)
+
+data = pd.DataFrame(dict(hypothesis=hypotheses, reference=references))
+
+
+# # Calculating the word error rate
+# 
+# Now, we use our English normalizer implementation to standardize the transcription and calculate the WER.
+
+import jiwer
+from whisper.normalizers import EnglishTextNormalizer
+
+normalizer = EnglishTextNormalizer()
+
+data["hypothesis_clean"] = [normalizer(text) for text in data["hypothesis"]]
+data["reference_clean"] = [normalizer(text) for text in data["reference"]]
+print(data)
+
+wer = jiwer.wer(list(data["reference_clean"]), list(data["hypothesis_clean"]))
+
+print(f"WER: {wer * 100:.2f} %")
+

--- a/radae_plots.m
+++ b/radae_plots.m
@@ -672,3 +672,106 @@ function v2_est_snr_plot(epslatex="")
     end
 endfunction
 
+
+# ASR Word Error Rate plots -------------------------------------------------------
+
+function plot_wer(prefix_fn, png_fn="", epslatex="")
+  ssb_awgn_fn = sprintf("%s_asr_awgn_ssb.txt",prefix_fn);
+  rade_awgn_fn = sprintf("%s_asr_awgn_rade.txt",prefix_fn);
+  freedv_700D_awgn_fn = sprintf("%s_asr_awgn_700D.txt",prefix_fn);
+  ssb_mpp_fn = sprintf("%s_asr_mpp_ssb.txt",prefix_fn);
+  rade_mpp_fn = sprintf("%s_asr_mpp_rade.txt",prefix_fn);
+  freedv_700D_mpp_fn = sprintf("%s_asr_mpp_700D.txt",prefix_fn);
+  controls_fn = sprintf("%s_asr_c.txt",prefix_fn);
+
+  ssb_awgn = load(ssb_awgn_fn);
+  rade_awgn = load(rade_awgn_fn);
+  freedv_700D_awgn = load(freedv_700D_awgn_fn);
+  ssb_mpp = load(ssb_mpp_fn);
+  rade_mpp = load(rade_mpp_fn);
+  freedv_700D_mpp = load(freedv_700D_mpp_fn);
+  c = load(controls_fn);
+  
+  if length(epslatex)
+    [textfontsize linewidth] = set_fonts(20);
+  end
+
+  # WER v C/No plot
+  figure(1); clf;
+  plot(ssb_awgn(:,2),ssb_awgn(:,3),'b+-;SSB AWGN;');
+  hold on;
+  plot(rade_awgn(:,2),rade_awgn(:,3),'g+-;RADE AWGN;');
+  plot(freedv_700D_awgn(:,2),freedv_700D_awgn(:,3),'r+-;700D AWGN;');
+  plot(ssb_mpp(:,2),ssb_mpp(:,3),'bo--;SSB MPP;');
+  plot(rade_mpp(:,2),rade_mpp(:,3),'go--;RADE MPP;');
+  plot(freedv_700D_mpp(:,2),freedv_700D_mpp(:,3),'ro--;700D MPP;');
+  xmin=30; xmax=60;
+  plot(xmax-5,c(1),'cx;clean;')
+  plot(xmax-5,c(2),'mo;FARGAN;')
+  plot(xmax-5,c(3),'k+;4kHz;')
+  hold off;
+  axis([xmin,xmax,0,40]); grid; ylabel('WER \%'); xlabel("C/No (dB)");
+
+  # WER v SNR plot
+  figure(2); clf;
+  plot(ssb_awgn(:,1),ssb_awgn(:,3),'b+-;SSB AWGN;');
+  hold on;
+  plot(rade_awgn(:,1),rade_awgn(:,3),'r+-;RADE AWGN;');
+  plot(freedv_700D_awgn(:,1),freedv_700D_awgn(:,3),'g+-;700D AWGN;');
+  plot(ssb_mpp(:,1),ssb_mpp(:,3),'bo--;SSB MPP;');
+  plot(rade_mpp(:,1),rade_mpp(:,3),'ro--;RADE MPP;');
+  plot(freedv_700D_mpp(:,1),freedv_700D_mpp(:,3),'go--;700D MPP;');
+  xmin=-5; xmax=20;
+  plot([xmin xmax],[c(2) c(2)],'m-;FARGAN;')
+  plot([xmin xmax],[c(1) c(1)],'c-;clean;')
+  hold off;
+  axis([xmin,xmax,0,40]); grid; ylabel('WER (\%)'); xlabel("SNR3k (dB)");
+  legend('boxoff'); legend("left");
+
+  if length(png_fn)
+    print("-dpng",png_fn,"-S800,600");
+  end
+  if length(epslatex)
+      print_eps_restore(epslatex,"-S250,250",textfontsize,linewidth);
+  end  
+endfunction
+
+function plot_wer_bbfm(prefix_fn, png_fn="", epslatex="")
+  fm_awgn_fn = sprintf("%s_asr_awgn_fm.txt",prefix_fn);
+  rade_awgn_fn = sprintf("%s_asr_awgn_bbfm.txt",prefix_fn);
+  fm_lmr60_fn = sprintf("%s_asr_lmr60_fm.txt",prefix_fn);
+  rade_lmr60_fn = sprintf("%s_asr_lmr60_bbfm.txt",prefix_fn);
+  controls_fn = sprintf("%s_asr_c.txt",prefix_fn);
+
+  fm_awgn = load(fm_awgn_fn);
+  rade_awgn = load(rade_awgn_fn);
+  fm_lmr60 = load(fm_lmr60_fn);
+  rade_lmr60 = load(rade_lmr60_fn);
+  c = load(controls_fn);
+
+  if length(epslatex)
+    [textfontsize linewidth] = set_fonts(30);
+  end
+
+  # WER v RdBm plot
+  figure(1); clf;
+  plot(fm_awgn(:,1),fm_awgn(:,2),'b+-;FM AWGN;');
+  hold on;
+  plot(rade_awgn(:,1),rade_awgn(:,2),'g+-;RADE AWGN;');
+  plot(fm_lmr60(:,1),fm_lmr60(:,2),'bo--;FM LMR60;');
+  plot(rade_lmr60(:,1),rade_lmr60(:,2),'go--;RADE LMR60;');
+  xmax=-100; xmin=-130; 
+  plot([xmin xmax],[c(3) c(3)],'r-;Codec 2 3200;')
+  plot([xmin xmax],[c(2) c(2)],'m-;FARGAN;')
+  plot([xmin xmax],[c(1) c(1)],'c-;clean;')
+  hold off;
+  axis([xmin,xmax,0,40]); grid; ylabel('WER \%'); xlabel("R (dBm)");
+  legend('boxoff');
+
+  if length(png_fn)
+    print("-dpng",png_fn,"-S800,600");
+  end
+  if length(epslatex)
+    print_eps_restore(epslatex,"-S250,250",textfontsize,linewidth);
+  end  
+endfunction


### PR DESCRIPTION
Reconciling ASR test scripts from https://github.com/drowe67/radae/pull/39 into main.  This work was used for ASR testing for RADE V1 and BBFM papers, and could be useful for more ASR tests (e.g.  RADE V2) in future.